### PR TITLE
chore: Prevent biohazard-alert from notifying when errors occur

### DIFF
--- a/.github/biohazard-alert.yml
+++ b/.github/biohazard-alert.yml
@@ -1,0 +1,1 @@
+notifyOnError: false


### PR DESCRIPTION
Added the ability to prevent biohazard-alert from notifying when an error occurs in https://github.com/atom/biohazard-alert/pull/28. Since it is still enabled by default, this config is required to prevent the notifications from happening org-wide.