### PR TITLE
ci: add faraday trust configuration

### DIFF
--- a/.github/faraday.yml
+++ b/.github/faraday.yml
@@ -1,0 +1,10 @@
+# faraday trust configuration — org-wide baseline.
+# A bot listed here is "trusted": its pull requests need 1 maintainer
+# approval instead of 2. Both `login` and `id` must match the PR author.
+# Find an ID with: gh api 'users/<login>' --jq .id
+# See: https://github.com/electron/faraday
+
+trusted-bots:
+  # Dependency bumps. Reviewed and approved by maintainers.
+  - login: dependabot[bot]
+    id: 49699333


### PR DESCRIPTION
Adds the `.github/faraday.yml` trust configuration for [faraday](https://github.com/electron/faraday), the GitHub App that enforces a two-person rule on pull requests across the `electron` org starting Monday.

A bot listed in `trusted-bots` has its pull requests treated as trusted (1 maintainer approval instead of 2), provided every commit is verifiably authored, committed, and signed by the bot. A bot listed under `approvers` may stand in for a human review on PRs authored by the bot it is paired with — and only that bot.

See the [faraday README](https://github.com/electron/faraday#trusted-bots) for the full policy.
