### PR TITLE
chore: add merge_group trigger to zizmor audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,7 @@
 name: zizmor Static Analysis
 
 on:
+  merge_group:
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
I believe this should unblock this status check in repos that use merge queues.

Refs https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue